### PR TITLE
Tree shakable re-ducks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Our examples will model a real duck.
 const QUACK = "app/duck/QUACK";
 const SWIM = "app/duck/SWIM";
 
-export default {
+export {
     QUACK,
     SWIM
 };
@@ -59,7 +59,7 @@ export default {
 ### Actions
 It's important to be consistent when defining actions, so let's always export functions from this file, we don't care if the action needs any input from the outside to build the payload or not.
 ```javascript
-import types from "./types";
+import * as types from "./types";
 
 const quack = ( ) => ( {
     type: types.QUACK
@@ -72,7 +72,7 @@ const swim = ( distance ) => ( {
     }
 } );
 
-export default {
+export {
     swim,
     quack
 };
@@ -86,7 +86,7 @@ The operations file define the `interface` for our duck. You can reason about it
 
 This separation should work with whatever middleware/lib you are using for handling chained/linked/delayed operations.
 ```javascript
-import actions from "./actions";
+import * as actions from "./actions";
 
 // This is a link to an action defined in actions.js.
 const simpleQuack = actions.quack;
@@ -99,7 +99,7 @@ const complexQuack = ( distance ) => ( dispatch ) => {
     } );
 }
 
-export default {
+export {
     simpleQuack,
     complexQuack
 };
@@ -112,7 +112,7 @@ It's a good practice to keep your **state shape** in a comment above the reducer
 In case the state shape is more complex, you should break the reducers into multiple smaller functions that deal with a slice of the state, then combine them at the end.
 ```javascript
 import { combineReducers } from "redux";
-import types from "./types";
+import * as types from "./types";
 
 /* State Shape
 {
@@ -155,7 +155,7 @@ function checkIfDuckIsInRange( duck ) {
     return duck.distance > 1000;
 }
 
-export default {
+export {
     checkIfDuckIsInRange
 };
 ```
@@ -169,9 +169,15 @@ This file, from a module perspective, behaves as the duck file form the original
 ```javascript
 import reducer from "./reducers";
 
-export { default as duckSelectors } from "./selectors";
-export { default as duckOperations } from "./operations";
-export { default as duckTypes } from "./types";
+import * as duckSelectors from "./selectors";
+import * as duckOperations from "./operations";
+import * as duckTypes from "./types";
+
+export {
+    duckSelectors,
+    duckOperations,
+    duckTypes
+};
 
 export default reducer;
 ```
@@ -183,7 +189,7 @@ Ultimately, this split proposed here is also helping you see what you need to te
 ```javascript
 import expect from "expect.js";
 import reducer from "./reducers";
-import actions from "./actions";
+import * as actions from "./actions";
 
 describe( "duck reducer", function( ) {
     describe( "quack", function( ) {

--- a/example-duck/actions.js
+++ b/example-duck/actions.js
@@ -5,7 +5,7 @@ HINT: Always use functions for consistency, don't export plain objects
 
 */
 
-import types from "./types";
+import * as types from "./types";
 
 const quack = ( ) => ( {
     type: types.QUACK
@@ -18,7 +18,7 @@ const swim = ( distance ) => ( {
     }
 } );
 
-export default {
+export {
     swim,
     quack
 };

--- a/example-duck/index.js
+++ b/example-duck/index.js
@@ -9,9 +9,16 @@ Optionally it exports the actions and types if they are needed in other ducks.
 
 import reducer from "./reducers";
 
-export { default as duckSelectors } from "./selectors";
-export { default as duckOperations } from "./operations";
-export { default as duckActions } from "./actions";
-export { default as duckTypes } from "./types";
+import * as duckSelectors from "./selectors";
+import * as duckOperations from "./operations";
+import * as duckActions from "./actions";
+import * as duckType from "./types";
+
+export {
+  duckSelectors,
+  duckOperations,
+  duckActions,
+  duckType
+};
 
 export default reducer;

--- a/example-duck/operations.js
+++ b/example-duck/operations.js
@@ -6,7 +6,7 @@ Complex operations involve returning a thunk that dispatches multiple actions in
 
 */
 
-import actions from "./actions";
+import * as actions from "./actions";
 
 const simpleQuack = actions.quack;
 
@@ -17,7 +17,7 @@ const complexQuack = ( distance ) => ( dispatch ) => {
     } );
 }
 
-export default {
+export {
     simpleQuack,
     complexQuack
 };

--- a/example-duck/reducers.js
+++ b/example-duck/reducers.js
@@ -6,7 +6,7 @@ Based on the state shape, multiple reducers might be defined in this file, combi
 */
 
 import { combineReducers } from "redux";
-import types from "./types";
+import * as types from "./types";
 
 /* State Shape
 {

--- a/example-duck/selectors.js
+++ b/example-duck/selectors.js
@@ -10,7 +10,7 @@ function checkIfDuckIsInRange( state ) {
     return state.duck.distance > 1000;
 }
 
-export default {
+export {
     checkIfDuckIsInRange
 };
 

--- a/example-duck/tests.js
+++ b/example-duck/tests.js
@@ -8,7 +8,7 @@ Example is using mocha and expect.js, but you can use any testing lib/framework/
 
 import expect from "expect.js";
 import reducer from "./reducers";
-import actions from "./actions";
+import * as actions from "./actions";
 
 describe( "duck reducer", function( ) {
     describe( "quack", function( ) {

--- a/example-duck/types.js
+++ b/example-duck/types.js
@@ -7,7 +7,7 @@ You can use any convention you wish here, but the name should remain UPPER_SNAKE
 const QUACK = "app/duck/QUACK";
 const SWIM = "app/duck/SWIM";
 
-export default {
+export {
     QUACK,
     SWIM
 };


### PR DESCRIPTION
This PR modifies the re-ducks proposal modules to export their functions/constants in a statically analyzable way for tools like rollup and webpack.

While it might not make sense to tree shake these ducks as they are very self contained and most likely you will use all the contents of it, I can see a case where an application is chunked and a certain chunk only includes types and reducers from a duck, and not the selectors or operations.

The proposal as stands is not tree shakable, and I have built a demo of the problem in a separate repo here: https://github.com/DiscoStarslayer/treeshaking-demo

If you agree with this change, I don't mind sending related PR's to the other codebase example projects.